### PR TITLE
Use pipeline variables for release tagging instead of git commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,11 @@ jobs:
       - run:
           name: Publish GitHub Release
           command: |
-            TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev-$(git rev-parse --short HEAD)")
+            if [ -z "<< pipeline.git.tag >>" ]; then
+              TAG="dev-<< pipeline.git.revision >>"
+            else
+              TAG="<< pipeline.git.tag >>"
+            fi
             gh release create "$TAG" ./bin/* --title "$TAG" --notes "Automated release from CircleCI"
 
 workflows:


### PR DESCRIPTION
This PR improves the GitHub release tagging by using pipeline variables instead of git commands.

When no tag is available:
- Uses pipeline.git.tag directly when available
- Falls back to dev-{pipeline.git.revision} for a unique identifier
