### PR TITLE
Switch to semver format for untagged releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,8 @@ jobs:
           name: Publish GitHub Release
           command: |
             if [ -z "<< pipeline.git.tag >>" ]; then
-              TAG="dev-<< pipeline.git.revision >>"
+              SHORT_HASH=${<< pipeline.git.revision >>:0:7}
+              TAG="0.0.0-${SHORT_HASH}"
             else
               TAG="<< pipeline.git.tag >>"
             fi


### PR DESCRIPTION
This PR changes the release naming convention for untagged releases to use semver format with git hash.

Changes:
- Instead of using 'dev-{hash}' for untagged releases, it now uses '0.0.0-{short_hash}'
- This follows semver naming conventions for pre-release identifiers
