### PR TITLE
fix(ci): allow BUILD_DATE variable to expand in release notes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
             # Create more informative release notes
             BUILD_DATE=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
 
-            cat > release_notes.md << EOT
+            cat > release_notes.md \<< EOT
             # Automated release from CircleCI
 
             **Build Information:**

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,20 +103,13 @@ jobs:
           command: |
             if [ -z "<< pipeline.git.tag >>" ]; then
               SHORT_HASH=$(echo "<< pipeline.git.revision >>" | cut -c1-7)
-              TAG="0.0.0-${SHORT_HASH}"
+              TAG="0.0.1-${SHORT_HASH}"
             else
               TAG="<< pipeline.git.tag >>"
             fi
 
-            # Create more informative release notes
-            BUILD_DATE=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
-
             cat > release_notes.md \<< EOT
             # Automated release from CircleCI
-
-            **Build Information:**
-            - Build Date: ${BUILD_DATE}
-            - Branch: << pipeline.git.branch >>
             - Commit: << pipeline.git.revision >>
             EOT
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,14 +110,12 @@ jobs:
 
             # Create more informative release notes
             BUILD_DATE=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
-            PIPELINE_URL="https://app.circleci.com/pipelines/github/circleci-petri/rule-tool/<< pipeline.number >>"
 
-            cat > release_notes.md \<< 'EOT'
+            cat > release_notes.md << EOT
             # Automated release from CircleCI
 
             **Build Information:**
             - Build Date: ${BUILD_DATE}
-            - CircleCI Pipeline: [#<< pipeline.number >>](${PIPELINE_URL})
             - Branch: << pipeline.git.branch >>
             - Commit: << pipeline.git.revision >>
             EOT


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Fixed the release notes script so the BUILD_DATE variable now expands correctly and shows the build date in the generated file.

<!-- End of auto-generated description by mrge. -->

<!-- Summary by @propel-code-bot -->

---

This PR fixes a syntax issue in the CircleCI configuration file that prevented the BUILD_DATE variable from properly expanding in generated release notes. The fix removes quotes around the heredoc delimiter 'EOT' and simplifies the release notes content.

*This summary was automatically generated by @propel-code-bot*