### PR TITLE
docs: add notes on Roo mode integration possibilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ go.work
 
 # OS specific
 .DS_Store
-Thumbs.db 
+Thumbs.db
 
 .cursor/rules/
+.roo/
+.roomodes

--- a/notes.md
+++ b/notes.md
@@ -1,2 +1,7 @@
 - Support Roo Code - they have a .roo folder, we should be able to export things like modes https://docs.roocode.com/features/custom-modes
 
+Ok - so the thing with roo is, we can transform into "modes" https://docs.roocode.com/features/custom-modes#mode-specific-instructions-via-filesdirectories
+
+by symln into the directory, and making a custom mode in .roomodes
+not sure its worth it?
+Or would it make more sense to do a tranform like that in CI alltogether?


### PR DESCRIPTION
This PR:
- Updates .gitignore to exclude .roo/ directory and .roomodes file
- Adds exploratory notes about potential Roo mode integration options
- Does NOT implement actual Roo mode support - just preliminary investigation and notes