### PR TITLE
feat: add git cloning and editor selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,6 @@ go.work
 Thumbs.db
 
 .cursor/rules/
+.windsurf/rules/
 .roo/
 .roomodes

--- a/.windsurf/rules/meow.md
+++ b/.windsurf/rules/meow.md
@@ -1,0 +1,11 @@
+---
+trigger: always_on
+description: Cat rule
+globs: 
+---
+# Rule at root directory for testing
+
+Just a rule for using to test the tool
+
+## Rule
+If I say Laser, respond with a random thing a cat would say

--- a/cmd/rule-tool/main.go
+++ b/cmd/rule-tool/main.go
@@ -23,7 +23,7 @@ func main() {
 	repoPath := flag.String("repo-path", "", "Path to the rules repository (overrides RULE_TOOL_PATH environment variable if set)")
 	targetPath := flag.String("target-path", "", "Path to the target project (overrides RULE_TARGET_PATH environment variable if set)")
 	gitRepoURL := flag.String("git-repo", "", "URL of a Git repository containing rules (overrides RULE_GIT_REPO_URL environment variable if set)")
-	editor := flag.String("editor", "", "Editor to use (cursor, vscode, neovim, vim) (overrides RULE_EDITOR environment variable if set)")
+	editor := flag.String("editor", "", "Editor to use (cursor, windsurf) (overrides RULE_EDITOR environment variable if set)")
 	nonInteractive := flag.Bool("non-interactive", false, "Run in non-interactive mode")
 	dryRun := flag.Bool("dry-run", false, "Show what would be done without making changes")
 	listRules := flag.Bool("list", false, "List available rules")

--- a/cmd/rule-tool/main.go
+++ b/cmd/rule-tool/main.go
@@ -27,8 +27,8 @@ func main() {
 	nonInteractive := flag.Bool("non-interactive", false, "Run in non-interactive mode")
 	dryRun := flag.Bool("dry-run", false, "Show what would be done without making changes")
 	listRules := flag.Bool("list", false, "List available rules")
-	linkRule := flag.String("link", "", "Link a specific rule or comma-separated list of rules")
-	unlinkRule := flag.String("unlink", "", "Unlink a specific rule or comma-separated list of rules")
+	linkRule := flag.String("link", "", "Install a specific rule or comma-separated list of rules")
+	unlinkRule := flag.String("unlink", "", "Uninstall a specific rule or comma-separated list of rules")
 	verbose := flag.Bool("verbose", false, "Enable verbose output")
 	flag.Parse()
 
@@ -83,7 +83,7 @@ func main() {
 			fmt.Println("Using default editor: cursor")
 		}
 
-		fmt.Printf("Rules will be linked to: %s\n", filepath.Join(cfg.TargetProjectPath, cfg.GetRulesDirectory()))
+		fmt.Printf("Rules will be installed to: %s\n", filepath.Join(cfg.TargetProjectPath, cfg.GetRulesDirectory()))
 	}
 
 	// Handle Git repository if URL is provided
@@ -231,7 +231,7 @@ func main() {
 		linkerInstance.SetConfig(cfg)
 
 		fmt.Printf("Selected editor: %s\n", cfg.Editor)
-		fmt.Printf("Rules will be linked to: %s\n", filepath.Join(cfg.TargetProjectPath, cfg.GetRulesDirectory()))
+		fmt.Printf("Rules will be installed to: %s\n", filepath.Join(cfg.TargetProjectPath, cfg.GetRulesDirectory()))
 	}
 
 	// Handle non-interactive modes if requested
@@ -265,7 +265,7 @@ func main() {
 					}
 
 					if *dryRun {
-						fmt.Printf("Would link rule: %s\n", ruleName)
+						fmt.Printf("Would install rule: %s\n", ruleName)
 
 						// Display subfolder structure if applicable
 						if rule.Topic != "" && *verbose {
@@ -274,9 +274,9 @@ func main() {
 					} else {
 						err := linkerInstance.LinkRule(rule)
 						if err != nil {
-							fmt.Printf("Error linking rule %s: %v\n", ruleName, err)
+							fmt.Printf("Error installing rule %s: %v\n", ruleName, err)
 						} else {
-							fmt.Printf("Linked rule: %s\n", ruleName)
+							fmt.Printf("Installed rule: %s\n", ruleName)
 						}
 					}
 				} else {
@@ -291,13 +291,13 @@ func main() {
 			for _, ruleName := range rulesToUnlink {
 				ruleName = strings.TrimSpace(ruleName)
 				if *dryRun {
-					fmt.Printf("Would unlink rule: %s\n", ruleName)
+					fmt.Printf("Would uninstall rule: %s\n", ruleName)
 				} else {
 					err := linkerInstance.UnlinkRule(ruleName)
 					if err != nil {
-						fmt.Printf("Error unlinking rule %s: %v\n", ruleName, err)
+						fmt.Printf("Error uninstalling rule %s: %v\n", ruleName, err)
 					} else {
-						fmt.Printf("Unlinked rule: %s\n", ruleName)
+						fmt.Printf("Uninstalled rule: %s\n", ruleName)
 					}
 				}
 			}

--- a/cmd/rule-tool/main.go
+++ b/cmd/rule-tool/main.go
@@ -206,25 +206,14 @@ func main() {
 
 	// If no editor is set and we're in interactive mode, prompt for editor selection
 	if !*nonInteractive && *linkRule == "" && *unlinkRule == "" && !*listRules && *editor == "" && os.Getenv(config.EnvEditor) == "" {
-		// Prompt for editor selection
-		fmt.Println("\nPlease select your editor:")
-		fmt.Println("1. Cursor (default)")
-		fmt.Println("2. Windsurf")
-		fmt.Print("Enter your choice (1-2): ")
-
-		var choice int
-		_, err := fmt.Scanf("%d", &choice)
-		if err != nil || choice < 1 || choice > 2 {
-			// Default to Cursor if invalid input
-			choice = 1
-			fmt.Println("Invalid choice, defaulting to Cursor")
-		}
-
-		switch choice {
-		case 1:
+		// Use bubbletea UI for editor selection
+		selectedEditor, err := ui.RunEditorSelection(cfg)
+		if err != nil {
+			fmt.Printf("Error selecting editor: %v\n", err)
+			// Default to Cursor if there's an error
 			cfg.SetEditor(string(config.EditorCursor))
-		case 2:
-			cfg.SetEditor(string(config.EditorWindsurf))
+		} else {
+			cfg.SetEditor(string(selectedEditor))
 		}
 
 		// Update the linker with the new config

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ type Editor string
 
 // Supported editors
 const (
-	EditorCursor  Editor = "cursor"
+	EditorCursor   Editor = "cursor"
 	EditorWindsurf Editor = "windsurf"
 )
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"os"
 	"testing"
+
+	"github.com/circleci/llm-agent-rules/internal/git"
 )
 
 func TestEnvVariables(t *testing.T) {
@@ -126,6 +128,16 @@ func TestDefaultValues(t *testing.T) {
 	if cfg.TargetProjectPath != cwd {
 		t.Errorf("Expected TargetProjectPath to be current directory %q, got %q", cwd, cfg.TargetProjectPath)
 	}
+
+	// Editor should default to Cursor
+	if cfg.Editor != EditorCursor {
+		t.Errorf("Expected Editor to be Cursor, got %s", cfg.Editor)
+	}
+
+	// Git repository should be disabled by default
+	if cfg.UseGitRepo {
+		t.Errorf("Expected UseGitRepo to be false, got true")
+	}
 }
 
 func TestDefaultPathValues(t *testing.T) {
@@ -170,5 +182,156 @@ func TestDefaultPathValues(t *testing.T) {
 	// Validate that ValidateTargetProjectPath works with default path
 	if !cfg.ValidateTargetProjectPath() {
 		t.Errorf("ValidateTargetProjectPath should return true for current directory %q", cwd)
+	}
+}
+
+func TestGetRulesDir(t *testing.T) {
+	cfg := New()
+
+	t.Run("No git repository", func(t *testing.T) {
+		want := "/some/path/rules"
+		cfg.UseGitRepo = false
+		cfg.RulesRepoPath = "/some/path"
+
+		got := cfg.GetRulesDir()
+
+		// Should return the rules repo path
+		if got != want {
+			t.Errorf("Expected GetRulesDir to return %q, got %q", want, got)
+		}
+	})
+
+	t.Run("With git repository", func(t *testing.T) {
+		want := "/some/path/.cursor/rules"
+		cfg.UseGitRepo = true
+		cfg.GitRepo = &git.Repository{
+			RulesPath: want,
+			CloneDir:  "/some/path",
+		}
+
+		got := cfg.GetRulesDir()
+
+		// Should return the git repository rules path
+		if got != want {
+			t.Errorf("Expected GetRulesDir to return %q, got %q", want, got)
+		}
+	})
+}
+
+func TestSetGitRepoURL(t *testing.T) {
+	t.Run("Set a git repository URL", func(t *testing.T) {
+		cfg := New()
+		gitURL := "https://github.com/test/test-repo.git"
+
+		cfg.SetGitRepoURL(gitURL)
+
+		// Should set the Git repository URL
+		if cfg.GitRepoURL != gitURL {
+			t.Errorf("Expected GitRepoURL to be set to %q, got %q", gitURL, cfg.GitRepoURL)
+		}
+
+		// Should enable UseGitRepo
+		if !cfg.UseGitRepo {
+			t.Errorf("Expected UseGitRepo to be true, got false")
+		}
+
+		// Should initialize Git repository
+		if cfg.GitRepo == nil {
+			t.Errorf("Expected Git repository to be initialized, got nil")
+		}
+
+		// Should set the URL in the Git repository
+		if cfg.GitRepo.URL != gitURL {
+			t.Errorf("Expected Git repository URL to be set to %q, got %q", gitURL, cfg.GitRepo.URL)
+		}
+	})
+	t.Run("Set an empty git repository URL", func(t *testing.T) {
+		cfg := New()
+
+		cfg.SetGitRepoURL("")
+
+		// Should disable UseGitRepo
+		if cfg.UseGitRepo {
+			t.Errorf("Expected UseGitRepo to be false, got true")
+		}
+
+		// Should set GitRepo to nil
+		if cfg.GitRepo != nil {
+			t.Errorf("Expected Git repository to be nil, got %v", cfg.GitRepo)
+		}
+	})
+}
+
+func TestSetEditor(t *testing.T) {
+	testCases := []struct {
+		name     string
+		editor   Editor
+		expected Editor
+	}{
+		{
+			name:     "Set Cursor editor",
+			editor:   EditorCursor,
+			expected: EditorCursor,
+		},
+		{
+			name:     "Set Windsurf editor",
+			editor:   EditorWindsurf,
+			expected: EditorWindsurf,
+		},
+		{
+			name:     "Set invalid editor",
+			editor:   Editor("invalid"),
+			expected: EditorCursor,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := New()
+
+			cfg.SetEditor(string(tc.editor))
+
+			// Should set the editor
+			if cfg.Editor != tc.expected {
+				t.Errorf("Expected Editor to be %s, got %s", tc.expected, cfg.Editor)
+			}
+		})
+	}
+}
+
+func TestGetRulesDirectory(t *testing.T) {
+	testCases := []struct {
+		name   string
+		editor Editor
+		want   string
+	}{
+		{
+			name:   "Cursor editor",
+			editor: EditorCursor,
+			want:   ".cursor/rules",
+		},
+		{
+			name:   "Windsurf editor",
+			editor: EditorWindsurf,
+			want:   ".windsurf/rules",
+		},
+		{
+			name:   "Invalid editor",
+			editor: Editor("invalid"),
+			want:   ".cursor/rules",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := New()
+
+			cfg.Editor = tc.editor
+
+			// Should return the expected rules directory
+			if cfg.GetRulesDirectory() != tc.want {
+				t.Errorf("Expected GetRulesDirectory to return %q, got %q", tc.want, cfg.GetRulesDirectory())
+			}
+		})
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -48,10 +48,10 @@ func (r *Repository) Clone() error {
 
 	// Set the clone directory
 	r.CloneDir = tempDir
-	
+
 	// Set the rules path
 	r.RulesPath = filepath.Join(r.CloneDir, ".cursor", "rules")
-	
+
 	return nil
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,82 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// Repository represents a Git repository
+type Repository struct {
+	URL       string // URL of the Git repository
+	CloneDir  string // Directory where the repository is cloned
+	RulesPath string // Path to the rules directory within the repository
+}
+
+// New creates a new Git repository instance
+func New(url string) *Repository {
+	return &Repository{
+		URL:       url,
+		CloneDir:  "",
+		RulesPath: "",
+	}
+}
+
+// Clone clones the Git repository to a temporary directory
+// Returns an error if the git command fails or if the repository URL is not set
+func (r *Repository) Clone() error {
+	if r.URL == "" {
+		return errors.New("git repository URL is not set")
+	}
+
+	// Create a temporary directory for the clone
+	tempDir, err := os.MkdirTemp("", "rule-tool-git-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+
+	// Clone the repository
+	cmd := exec.Command("git", "clone", r.URL, tempDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Clean up the temporary directory if the clone fails
+		_ = os.RemoveAll(tempDir)
+		return fmt.Errorf("git clone failed: %w, output: %s", err, string(output))
+	}
+
+	// Set the clone directory
+	r.CloneDir = tempDir
+	
+	// Set the rules path
+	r.RulesPath = filepath.Join(r.CloneDir, ".cursor", "rules")
+	
+	return nil
+}
+
+// Cleanup removes the temporary directory where the git repository was cloned
+func (r *Repository) Cleanup() error {
+	if r.CloneDir == "" {
+		return nil
+	}
+
+	err := os.RemoveAll(r.CloneDir)
+	if err != nil {
+		return fmt.Errorf("failed to remove git clone directory: %w", err)
+	}
+
+	r.CloneDir = ""
+	r.RulesPath = ""
+	return nil
+}
+
+// GetRulesPath returns the path to the rules directory in the repository
+func (r *Repository) GetRulesPath() string {
+	return r.RulesPath
+}
+
+// IsCloned returns true if the repository has been cloned
+func (r *Repository) IsCloned() bool {
+	return r.CloneDir != ""
+}

--- a/internal/linker/linker.go
+++ b/internal/linker/linker.go
@@ -43,7 +43,7 @@ func (l *Linker) SetVerbose(verbose bool) {
 // SetConfig sets the configuration for the linker
 func (l *Linker) SetConfig(cfg *config.Config) {
 	l.Config = cfg
-	
+
 	// Enable copy mode if using a git repository
 	if cfg != nil && cfg.UseGitRepo {
 		l.CopyMode = true

--- a/internal/ui/editor_selection.go
+++ b/internal/ui/editor_selection.go
@@ -1,0 +1,145 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/circleci/llm-agent-rules/internal/config"
+)
+
+// EditorOption represents an editor choice
+type EditorOption struct {
+	name        string
+	description string
+	value       config.Editor
+}
+
+// FilterValue implements list.Item interface
+func (e EditorOption) FilterValue() string {
+	return e.name
+}
+
+// Title returns the editor name
+func (e EditorOption) Title() string {
+	return e.name
+}
+
+// Description returns the editor description
+func (e EditorOption) Description() string {
+	return e.description
+}
+
+// EditorSelectionModel represents the editor selection UI
+type EditorSelectionModel struct {
+	list   list.Model
+	choice config.Editor
+	done   bool
+	cfg    *config.Config
+}
+
+// NewEditorSelectionModel creates a new editor selection model
+func NewEditorSelectionModel(cfg *config.Config) *EditorSelectionModel {
+	// Define available editors
+	editors := []list.Item{
+		EditorOption{
+			name:        "Cursor",
+			description: "Use Cursor editor integration",
+			value:       config.EditorCursor,
+		},
+		EditorOption{
+			name:        "Windsurf",
+			description: "Use Windsurf editor integration",
+			value:       config.EditorWindsurf,
+		},
+	}
+
+	// Create local style definitions
+	titleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("#FFFFFF")).
+		Background(lipgloss.Color("#8A2BE2")).
+		Padding(0, 1)
+
+	paginationStyle := lipgloss.NewStyle().
+		PaddingLeft(4).
+		Foreground(lipgloss.Color("#FFFF00"))
+
+	helpStyle := lipgloss.NewStyle().
+		PaddingLeft(4).
+		PaddingBottom(1).
+		Foreground(lipgloss.Color("#00FFFF"))
+
+	// Create a new list
+	l := list.New(editors, list.NewDefaultDelegate(), 0, 0)
+	l.Title = "Select Your Editor"
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(false)
+	l.Styles.Title = titleStyle
+	l.Styles.PaginationStyle = paginationStyle
+	l.Styles.HelpStyle = helpStyle
+
+	return &EditorSelectionModel{
+		list:   l,
+		choice: config.EditorCursor, // Default to Cursor
+		cfg:    cfg,
+	}
+}
+
+// Init initializes the model
+func (m *EditorSelectionModel) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles user input
+func (m *EditorSelectionModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q":
+			return m, tea.Quit
+		case "enter":
+			// Get the selected editor
+			if i, ok := m.list.SelectedItem().(EditorOption); ok {
+				m.choice = i.value
+			}
+			m.done = true
+			return m, tea.Quit
+		}
+	case tea.WindowSizeMsg:
+		h, v := docStyle.GetFrameSize()
+		m.list.SetSize(msg.Width-h, msg.Height-v)
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+// View renders the UI
+func (m *EditorSelectionModel) View() string {
+	if m.done {
+		return ""
+	}
+	// Create a document style
+	docStyle := lipgloss.NewStyle().Padding(1, 2, 1, 2)
+	return docStyle.Render(m.list.View())
+}
+
+// GetSelectedEditor returns the selected editor
+func (m *EditorSelectionModel) GetSelectedEditor() config.Editor {
+	return m.choice
+}
+
+// RunEditorSelection runs the editor selection UI and returns the selected editor
+func RunEditorSelection(cfg *config.Config) (config.Editor, error) {
+	m := NewEditorSelectionModel(cfg)
+	p := tea.NewProgram(m, tea.WithAltScreen())
+
+	if _, err := p.Run(); err != nil {
+		return config.EditorCursor, fmt.Errorf("error running editor selection: %w", err)
+	}
+
+	return m.GetSelectedEditor(), nil
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -458,9 +458,17 @@ func (m Model) View() string {
 		"• /: Filter rules\n" +
 		"• q: Quit"
 
-	infoContent := "Repository Info:\n" +
-		"• Rules: " + rulesRepoPath + "\n" +
-		"• Target: " + targetPath + "\n\n" +
+	// Prepare repository info content
+	infoContent := "Repository Info:\n"
+	
+	// Show Git repository URL if using Git
+	if m.config.UseGitRepo {
+		infoContent += "• Git Repo: " + m.config.GitRepoURL + "\n"
+	} else {
+		infoContent += "• Rules: " + rulesRepoPath + "\n"
+	}
+	
+	infoContent += "• Target: " + targetPath + "\n\n" +
 		"Indicators:\n" +
 		"• [INSTALLED]: Rule is already installed\n" +
 		"• ✓: Rule is selected for installation"

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -329,7 +329,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 
 					// Show success message
-					m.successMessage = fmt.Sprintf("✓ Successfully linked %d rules!", len(selected))
+					m.successMessage = fmt.Sprintf("✓ Successfully installed %d rules!", len(selected))
 					m.showingSuccess = true
 
 					// Clear success message after a short delay

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -454,20 +454,20 @@ func (m Model) View() string {
 		"• Enter: Toggle selection\n" +
 		"• a: Select all\n" +
 		"• d: Deselect all\n" +
-		"• l: Link selected rules\n" +
+		"• l: Install selected rules\n" +
 		"• /: Filter rules\n" +
 		"• q: Quit"
 
 	// Prepare repository info content
 	infoContent := "Repository Info:\n"
-	
+
 	// Show Git repository URL if using Git
 	if m.config.UseGitRepo {
 		infoContent += "• Git Repo: " + m.config.GitRepoURL + "\n"
 	} else {
 		infoContent += "• Rules: " + rulesRepoPath + "\n"
 	}
-	
+
 	infoContent += "• Target: " + targetPath + "\n\n" +
 		"Indicators:\n" +
 		"• [INSTALLED]: Rule is already installed\n" +

--- a/test_git_repo.sh
+++ b/test_git_repo.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Test script for the Git repository URL functionality
+
+echo "Testing rule-tool with Git repository URL..."
+
+# Test with a public Git repository URL
+./rule-tool --git-repo=https://github.com/example/rules-repo --verbose --list
+
+# Test with dry run
+./rule-tool --git-repo=https://github.com/example/rules-repo --verbose --dry-run --link=example-rule
+
+echo "Tests completed."


### PR DESCRIPTION
This PR adds the ability to select a git repo to clone the rules from, and adds the possibility to choose from either Cursor or Windsurf to adapt the rule directory.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added support for cloning rules from a Git repository and let users choose between Cursor or Windsurf as the target editor for rule installation.

- **New Features**
  - Added `--git-repo` flag to clone rules from a remote Git repository.
  - Added `--editor` flag and interactive prompt to select Cursor or Windsurf, installing rules to the correct directory.
  - When using a Git repo, rules are copied instead of symlinked.
  - Updated CLI and UI messages to use "install" instead of "link".

<!-- End of auto-generated description by mrge. -->

<!-- Summary by @propel-code-bot -->

---

**Enhanced Rule Management: Git Cloning and Editor Selection**

This PR introduces two major features: the ability to clone rules from Git repositories and the option to select between Cursor and Windsurf editors for rule installation. It transitions from a symlink-only approach to supporting file copying for Git-sourced rules, and updates terminology throughout the UI and CLI from 'link' to 'install' to better reflect the tool's purpose.

**Key Changes:**
• Added support for cloning rules from Git repositories with proper cleanup
• Added editor selection ``UI`` to choose between Cursor and Windsurf editors
• Implemented file copying mode for Git-sourced rules instead of symlinks
• Updated path handling to use editor-specific rules directories
• Improved terminology from `link` to `install` throughout the ``UI`` and ``CLI``

**Affected Areas:**
• Configuration system (internal/config)
• Git repository handling (internal/git)
• Rule linking/copying mechanism (internal/linker)
• ``CLI`` interface (cmd/rule-tool)
• ``UI`` components (internal/ui)

**Potential Impact:**

**Functionality**: Significantly expands the tool's flexibility by enabling remote rule repositories and multi-editor support

**Performance**: Git operations may introduce network-dependent delays when cloning repositories

**Security**: Increased attack surface through Git operations - relies on Git's security model for repo access

**Scalability**: Improves scalability by allowing centralized rule management via Git repositories

**Review Focus:**
• Fix hardcoded Cursor path in git repository handling
• Address issue with rule file extensions (.md vs .mdc)
• Error handling during Git operations
• Temporary directory cleanup implementation
• Editor-specific path resolution logic

<details>
<summary><strong>Testing Needed</strong></summary>

• Test Git repository cloning with valid and invalid `URLs`
• Verify correct path resolution for different editors
• Test file copying behavior for Git sources vs. symlink behavior for local sources
• Verify temporary Git directory cleanup
• Test interactive editor selection ``UI`` flow
• Verify rules are correctly installed in the appropriate editor directory

</details>

<details>
<summary><strong>Code Quality Assessment</strong></summary>

**internal/git/git.go**: Well-structured but has hardcoded paths that don't respect editor selection

**internal/config/config.go**: Good addition of editor-specific functions with proper validation

**internal/linker/linker.go**: Effectively refactored to handle both symlinks and copying

**cmd/rule-tool/main.go**: Growing complexity - could benefit from further modularization

**internal/ui/editor_selection.go**: Well-designed UI component with good separation of concerns

</details>

<details>
<summary><strong>Best Practices</strong></summary>

**Error Handling**:
• Comprehensive error capture and reporting
• Cleanup attempts even after errors

**Configuration**:
• Environment variables with command-line override
• Clear configuration validation

**Ui**:
• Good separation of model and view
• Consistent terminology

</details>

<details>
<summary><strong>Possible Issues</strong></summary>

• Git repository clone method doesn't accept an editor parameter to determine correct rules path
• Rule file has .md extension but code expects .mdc extension
• Empty 'globs' field in sample rule file
• No validation of repository structure before attempting to use rules
• No handling for Git credentials for private repositories

</details>

---
*This summary was automatically generated by @propel-code-bot*

