### PR TITLE
feat: add editor modal help entry

### DIFF
--- a/internal/ui/components/modal.go
+++ b/internal/ui/components/modal.go
@@ -15,8 +15,7 @@ var (
 			Width(50)
 
 	buttonStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#000000")).
-			Background(lipgloss.Color("#5f5fd7")).
+			Foreground(lipgloss.Color("#FFFFFF")).
 			Padding(0, 1)
 
 	activeButtonStyle = lipgloss.NewStyle().

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -363,6 +363,7 @@ func (m *Model) createHelpContent() string {
 		"• Enter: Toggle selection\n" +
 		"• a: Select all\n" +
 		"• d: Deselect all\n" +
+		"• e: Open editor modal\n" +
 		"• l: Link selected rules\n" +
 		"• /: Filter rules\n" +
 		"• q: Quit"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added the "e: Open editor modal" shortcut to the help content and updated the modal button text color for better visibility.

<!-- End of auto-generated description by cubic. -->

<!-- Summary by @propel-code-bot -->

---

This PR introduces the editor modal shortcut ('e') to the UI help section, making it clear to users how to access the editor modal. Additionally, it updates the modal component's button text foreground color to improve visual clarity.

*This summary was automatically generated by @propel-code-bot*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a help description indicating that pressing "e" opens the editor modal.

- **Style**
  - Updated modal button text color to white for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->